### PR TITLE
Permissions & Escaping

### DIFF
--- a/src/Controller/PerspectiveController.php
+++ b/src/Controller/PerspectiveController.php
@@ -2,6 +2,7 @@
 
 namespace Pimcore\Bundle\PerspectiveEditorBundle\Controller;
 
+use Pimcore\Bundle\PerspectiveEditorBundle\PimcorePerspectiveEditorBundle;
 use Pimcore\Bundle\PerspectiveEditorBundle\Services\PerspectiveAccessor;
 use Pimcore\Bundle\PerspectiveEditorBundle\Services\TreeHelper;
 use Pimcore\Bundle\PerspectiveEditorBundle\Services\ViewAccessor;
@@ -22,7 +23,9 @@ class PerspectiveController extends AdminController {
      * @param TreeHelper $treeHelper
      * @return JsonResponse
      */
-    public function getPerspectiveTreeAction(PerspectiveAccessor $perspectiveAccessor, TreeHelper $treeHelper){
+    public function getPerspectiveTreeAction(PerspectiveAccessor $perspectiveAccessor, TreeHelper $treeHelper) {
+        $this->checkPermission(PimcorePerspectiveEditorBundle::PERMISSION_PERSPECTIVE_EDITOR);
+
         $tree = [];
         $configuration = $perspectiveAccessor->getConfiguration();
 
@@ -41,7 +44,9 @@ class PerspectiveController extends AdminController {
      * @param TreeHelper $treeHelper
      * @return JsonResponse
      */
-    public function getViewTreeAction(ViewAccessor $viewAccessor, TreeHelper $treeHelper){
+    public function getViewTreeAction(ViewAccessor $viewAccessor, TreeHelper $treeHelper) {
+        $this->checkPermission(PimcorePerspectiveEditorBundle::PERMISSION_PERSPECTIVE_EDITOR);
+
         $tree = [];
 
         $configuration = $viewAccessor->getConfiguration();
@@ -62,11 +67,14 @@ class PerspectiveController extends AdminController {
      * @return JsonResponse
      */
     public function updatePerspectivesAction(PerspectiveAccessor $perspectiveAccessor, Request $request){
+        $this->checkCsrfToken($request);
+        $this->checkPermission(PimcorePerspectiveEditorBundle::PERMISSION_PERSPECTIVE_EDITOR);
+
         $ret = [
             'success' => true,
             'error' => null
         ];
-        try{
+        try {
             $treeStore = json_decode($request->get('data'), true);
 
             $this->checkForUniqueElements($treeStore);
@@ -87,6 +95,11 @@ class PerspectiveController extends AdminController {
      * @return JsonResponse
      */
     public function updateViewAction(ViewAccessor $viewAccessor, Request $request){
+        $this->checkCsrfToken($request);
+        if(!$this->getAdminUser() || !$this->getAdminUser()->isAdmin()) {
+            throw $this->createAccessDeniedHttpException('Access denied, only Admin users are allowed to update views');
+        }
+
         $ret = [
             'success' => true,
             'error' => null

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Pimcore\Bundle\PerspectiveEditorBundle;
+
+use Pimcore\Bundle\DataHubBundle\Controller\ConfigController;
+use Pimcore\Db;
+use Pimcore\Extension\Bundle\Installer\AbstractInstaller;
+use Pimcore\Logger;
+use Pimcore\Model\User\Permission\Definition;
+
+class Installer extends AbstractInstaller
+{
+    public function needsReloadAfterInstall(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canBeInstalled(): bool
+    {
+        return !$this->isInstalled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isInstalled(): bool
+    {
+        $db = Db::get();
+        $check = $db->fetchOne("SELECT `key` FROM users_permission_definitions where `key` = ?", [PimcorePerspectiveEditorBundle::PERMISSION_PERSPECTIVE_EDITOR]);
+
+        return (bool)$check;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install()
+    {
+        Definition::create(PimcorePerspectiveEditorBundle::PERMISSION_PERSPECTIVE_EDITOR);
+        return true;
+    }
+}

--- a/src/PimcorePerspectiveEditorBundle.php
+++ b/src/PimcorePerspectiveEditorBundle.php
@@ -9,6 +9,8 @@ class PimcorePerspectiveEditorBundle extends AbstractPimcoreBundle
 {
     use PackageVersionTrait;
 
+    const PERMISSION_PERSPECTIVE_EDITOR = 'perspective_editor';
+
     public function getJsPaths()
     {
         return [
@@ -31,4 +33,10 @@ class PimcorePerspectiveEditorBundle extends AbstractPimcoreBundle
     {
         return "pimcore/perspective-editor";
     }
+
+    public function getInstaller()
+    {
+        return $this->container->get(Installer::class);
+    }
+
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -13,3 +13,7 @@ services:
 
     Pimcore\Bundle\PerspectiveEditorBundle\Services\:
         resource: '../../Services'
+
+
+    Pimcore\Bundle\PerspectiveEditorBundle\Installer:
+        public: true

--- a/src/Resources/public/js/pimcore/perspective/common.js
+++ b/src/Resources/public/js/pimcore/perspective/common.js
@@ -16,10 +16,11 @@ pimcore.bundle.perspectiveeditor.PerspectiveViewHelper = class {
         record.parentNode.expand();
     }
 
-    static generateCheckbox (label, config, key, inverted = false, changeCallback){
+    static generateCheckbox (label, config, key, inverted = false, changeCallback = null, readOnly = false){
         return new Ext.form.Checkbox({
             boxLabel: label,
             checked: inverted ? !config[key] : config[key],
+            readOnly: readOnly,
             listeners: {
                 change: function(elem, newValue, oldValue){
                     config[key] = newValue;
@@ -70,7 +71,7 @@ pimcore.bundle.perspectiveeditor.PerspectiveViewHelper = class {
         }
     }
 
-    static generateCheckboxesForStructure (configStructure, checkboxItems, callback, labelPrefix) {
+    static generateCheckboxesForStructure (configStructure, checkboxItems, callback, labelPrefix, readOnly) {
 
         const keys = Object.keys(configStructure);
         keys.sort();
@@ -85,12 +86,12 @@ pimcore.bundle.perspectiveeditor.PerspectiveViewHelper = class {
                 if(Number.isInteger(configStructure[key]) || typeof configStructure[key] === "boolean") {
 
                     //create checkbox for permission
-                    checkboxItems.push(this.generateCheckbox(t(label), configStructure, key, false, callback));
+                    checkboxItems.push(this.generateCheckbox(t(label), configStructure, key, false, callback, readOnly));
 
                 } else {
 
                     //create checkboxes for sub-items
-                    this.generateCheckboxesForStructure(configStructure[key], checkboxItems, callback, label);
+                    this.generateCheckboxesForStructure(configStructure[key], checkboxItems, callback, label, readOnly);
 
                 }
             }

--- a/src/Resources/public/js/pimcore/perspective/startup.js
+++ b/src/Resources/public/js/pimcore/perspective/startup.js
@@ -14,6 +14,8 @@ pimcore.settings.perspectiveview = Class.create({
 
     getTabPanel: function () {
         if (!this.panel) {
+            const user = pimcore.globalmanager.get('user');
+
             this.panel = new Ext.Panel({
                 id: this.panelId,
                 iconCls: 'pimcore_nav_icon_perspective',
@@ -25,7 +27,7 @@ pimcore.settings.perspectiveview = Class.create({
                     new Ext.TabPanel({
                         items: [
                             new pimcore.bundle.perspectiveeditor.PerspectiveEditor(),
-                            new pimcore.bundle.perspectiveeditor.ViewEditor(),
+                            new pimcore.bundle.perspectiveeditor.ViewEditor(!user.admin),
                         ],
                     }),
                 ],
@@ -59,19 +61,25 @@ pimcore.settings.perspectiveview = Class.create({
     },
 
     pimcoreReady: function(){
-        var menu = pimcore.globalmanager.get('layout_toolbar').settingsMenu;
-        menu.add({
-            text: t('plugin_pimcore_perspectiveeditor_perspective_view_editor'),
-            iconCls: 'pimcore_nav_icon_perspective',
-            handler: function(){
-                try{
-                    pimcore.globalmanager.get('plugin_pimcore_perspectiveeditor').activate();
-                } catch (e) {
-                    this.getTabPanel();
-                    pimcore.globalmanager.add('plugin_pimcore_perspectiveeditor', this);
-                }
-            }.bind(this)
-        });
+        const perspectiveCfg = pimcore.globalmanager.get('perspective');
+        const user = pimcore.globalmanager.get('user');
+        const menu = pimcore.globalmanager.get('layout_toolbar').settingsMenu;
+
+        if(menu && perspectiveCfg.inToolbar('settings.perspectiveEditor') && user.isAllowed('perspective_editor')) {
+            menu.add({
+                text: t('plugin_pimcore_perspectiveeditor_perspective_view_editor'),
+                iconCls: 'pimcore_nav_icon_perspective',
+                handler: function(){
+                    try{
+                        pimcore.globalmanager.get('plugin_pimcore_perspectiveeditor').activate();
+                    } catch (e) {
+                        this.getTabPanel();
+                        pimcore.globalmanager.add('plugin_pimcore_perspectiveeditor', this);
+                    }
+                }.bind(this)
+            });
+        }
+
     },
 });
 

--- a/src/Resources/translations/admin.de.yml
+++ b/src/Resources/translations/admin.de.yml
@@ -1,6 +1,7 @@
 plugin_pimcore_perspectiveeditor_perspective_view_editor: "Perspektiven / Ansichten"
 plugin_pimcore_perspectiveeditor_no_unique_treeelements: "In den Elementbäumen dürfen max. jeweils einmal den Typ Dokument, Asset und Datenobjekt enthalten"
 
+perspective_editor: "Perspektiveneditor"
 plugin_pimcore_perspectiveeditor_perspective_editor: "Perspektiveneditor"
 plugin_pimcore_perspectiveeditor_available_perspectives: "Verfügbare Perspektiven"
 plugin_pimcore_perspectiveeditor_add_perspective: "Perspektive hinzufügen"

--- a/src/Resources/translations/admin.en.yml
+++ b/src/Resources/translations/admin.en.yml
@@ -1,6 +1,7 @@
 plugin_pimcore_perspectiveeditor_perspective_view_editor: "Perspectives / Views"
 plugin_pimcore_perspectiveeditor_no_unique_treeelements: "Element tree elements may contain a maximum of one type of document, asset and data object"
 
+perspective_editor: "Perspective Editor"
 plugin_pimcore_perspectiveeditor_perspective_editor: "Perspective Editor"
 plugin_pimcore_perspectiveeditor_available_perspectives: "Available Perspectives"
 plugin_pimcore_perspectiveeditor_add_perspective: "Add Perspective"

--- a/src/Services/AbstractAccessor.php
+++ b/src/Services/AbstractAccessor.php
@@ -24,7 +24,7 @@ abstract class AbstractAccessor {
                         . $this->pretty_export($value, "$indent    ");
                 }
                 return "[\n" . implode(",\n", $r) . "\n" . $indent . ']';
-            case 'string': return "'" . addcslashes(str_replace("'", '"', $var), "\\\$\"\r\n\t\v\f") . "'";
+            case 'string': return '"' . addcslashes(str_replace('"', '"', $var), "\\\$\r\"\n\t\v\f") . '"';
             case 'boolean': return $var ? 'true' : 'false';
             case 'integer':
             case 'double': return $var;


### PR DESCRIPTION
- added Permission `perspective_editor` for perspective editor
  - allows editing perspectives
  - customViews available readonly only - due to security problems

- only admins have also write access to customViews

- fixed data escaping
