### PR TITLE
Fix custom view context menu in perspectives

### DIFF
--- a/src/Services/PerspectiveAccessor.php
+++ b/src/Services/PerspectiveAccessor.php
@@ -41,6 +41,10 @@ class PerspectiveAccessor extends AbstractAccessor
                                         unset($grandchild['config']['treeContextMenu'][$contextMenuEntry]);
                                     }
                                 }
+
+                                if(empty($grandchild['config']['treeContextMenu'])) {
+                                    unset($grandchild['config']['treeContextMenu']);
+                                }
                             }
                             $grandchild['config']['sort'] = $sortIndex;
                             $grandchild['config']['position'] = 'left';

--- a/src/Services/PerspectiveAccessor.php
+++ b/src/Services/PerspectiveAccessor.php
@@ -42,7 +42,7 @@ class PerspectiveAccessor extends AbstractAccessor
                                     }
                                 }
 
-                                if(empty($grandchild['config']['treeContextMenu'])) {
+                                if (empty($grandchild['config']['treeContextMenu'])) {
                                     unset($grandchild['config']['treeContextMenu']);
                                 }
                             }


### PR DESCRIPTION
empty context menu config in perspective must not be set ... otherwise settings from custom view are not applied. 