### PR TITLE
Bug: View Editor switching back to a previously opened object view throws JS error

### DIFF
--- a/src/Resources/public/js/pimcore/perspective/view.js
+++ b/src/Resources/public/js/pimcore/perspective/view.js
@@ -277,7 +277,11 @@ pimcore.bundle.perspectiveeditor.ViewEditor = class {
         classesStore.load({
             "callback": function (classes, success) {
                 if (success && classes) {
-                    Ext.getCmp('allowed_object_classes').setValue(classes.join(","));
+                    let value = classes;
+                    if(typeof classes !== "string") {
+                        value = classes.join(",");
+                    }
+                    Ext.getCmp('allowed_object_classes').setValue(value);
                 }
             }.bind(this, data.config.classes)
         });


### PR DESCRIPTION
Resolves #79 