### PR TITLE
Empty contextmenu config override for right panels

### DIFF
--- a/src/Services/PerspectiveAccessor.php
+++ b/src/Services/PerspectiveAccessor.php
@@ -63,6 +63,9 @@ class PerspectiveAccessor extends AbstractAccessor
                                         unset($grandchild['config']['treeContextMenu'][$contextMenuEntry]);
                                     }
                                 }
+                                if (empty($grandchild['config']['treeContextMenu'])) {
+                                    unset($grandchild['config']['treeContextMenu']);
+                                }                                
                             }
                             $grandchild['config']['sort'] = $sortIndex;
                             $grandchild['config']['position'] = 'right';

--- a/src/Services/PerspectiveAccessor.php
+++ b/src/Services/PerspectiveAccessor.php
@@ -65,7 +65,7 @@ class PerspectiveAccessor extends AbstractAccessor
                                 }
                                 if ($grandchild['config']['treeContextMenu'] === []) {
                                     unset($grandchild['config']['treeContextMenu']);
-                                }                                
+                                }
                             }
                             $grandchild['config']['sort'] = $sortIndex;
                             $grandchild['config']['position'] = 'right';

--- a/src/Services/PerspectiveAccessor.php
+++ b/src/Services/PerspectiveAccessor.php
@@ -45,7 +45,7 @@ class PerspectiveAccessor extends AbstractAccessor
                                     }
                                 }
 
-                                if (empty($grandchild['config']['treeContextMenu'])) {
+                                if ($grandchild['config']['treeContextMenu'] === []) {
                                     unset($grandchild['config']['treeContextMenu']);
                                 }
                             }
@@ -63,7 +63,7 @@ class PerspectiveAccessor extends AbstractAccessor
                                         unset($grandchild['config']['treeContextMenu'][$contextMenuEntry]);
                                     }
                                 }
-                                if (empty($grandchild['config']['treeContextMenu'])) {
+                                if ($grandchild['config']['treeContextMenu'] === []) {
                                     unset($grandchild['config']['treeContextMenu']);
                                 }                                
                             }


### PR DESCRIPTION
It's applying missed fix for right panels https://github.com/pimcore/perspective-editor/commit/124ca46b82ed03a29cc30747577e5f930c22ecb9, because now On saving custom view configuration stores empty array and it ignores configured actions setup - all menu items are still avaialble: 

 ```
[
               "type" => "customview",
                "position" => "right",
                "sort" => 3,
                "treeContextMenu" => [

                ],
                "id" => "bf2180f1-c529-99d5-9538-84cafa325477"
]
```
