### PR TITLE
Bug: Sanitize name on rename, and allow space on creation.

### DIFF
--- a/src/Resources/public/js/pimcore/perspective/perspective.js
+++ b/src/Resources/public/js/pimcore/perspective/perspective.js
@@ -300,6 +300,7 @@ pimcore.bundle.perspectiveeditor.PerspectiveEditor = class {
             handler: function(){
                 if(record.data["writeable"] === true) {
                     Ext.MessageBox.prompt(t('plugin_pimcore_perspectiveeditor_rename'), t('plugin_pimcore_perspectiveeditor_perspective_rename'), function (button, value) {
+                        value = this.sanitizeName(value);
                         if (button === 'ok' && value !== record.data.text) {
                             //check for configs with same name
                             let match = this.perspectiveTreeStore.findExact("name", value);
@@ -853,7 +854,7 @@ pimcore.bundle.perspectiveeditor.PerspectiveEditor = class {
     }
 
     sanitizeName (name) {
-        return name.replace(/[^a-z0-9_\-.+]/gi,'');
+        return name.replace(/[^a-z0-9_\-.+\s]/gi,'');
     }
 
 }


### PR DESCRIPTION
The perspective editor was sanitizing on creation. But after creation, it was not using the same sanitize function when renaming. Updated to use the sanitize method, but also allow spaces if the name requires it.