### PR TITLE
Remove unnecessary dependency on symfony/http-foundation from compose…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "php": "~8.3.0 || ~8.4.0",
     "pimcore/compatibility-bridge-v10": "^2.0",
     "pimcore/admin-ui-classic-bundle": "^2.0",
-    "pimcore/pimcore": "^12.0"
+    "pimcore/pimcore": "^12.3"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "php": "~8.3.0 || ~8.4.0",
     "pimcore/compatibility-bridge-v10": "^2.0",
     "pimcore/admin-ui-classic-bundle": "^2.0",
-    "pimcore/pimcore": "^12.0",
-    "symfony/http-foundation": "^6.3"
+    "pimcore/pimcore": "^12.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.2",


### PR DESCRIPTION
This pull request makes a minor update to the `composer.json` file by removing the `symfony/http-foundation` dependency from the list of required packages. This change streamlines the project's dependencies and may indicate that `symfony/http-foundation` is no longer directly needed.

Dependency update:

* Removed `symfony/http-foundation` from the required dependencies in `composer.json`.…r.json