### PR TITLE
[Task]: Update Codeception workflow to remove experimental pimcore

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -32,7 +32,6 @@ jobs:
                 include:
                     - { php-version: 8.3, database: "mariadb:10.11", pimcore_version: "", dependencies: highest, experimental: false }
                     - { php-version: 8.4, database: "mariadb:10.11", pimcore_version: "", dependencies: highest, experimental: false }
-                    - { php-version: 8.4, database: "mariadb:10.11", pimcore_version: "12.x-dev", dependencies: highest, experimental: true }
         services:
             mariadb:
                 image: "${{ matrix.database }}"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,7 +22,6 @@ jobs:
                 include:
                     - { php-version: "8.3", dependencies: "highest", pimcore_version: "", phpstan_args: "", experimental: false }
                     - { php-version: "8.4", dependencies: "highest", pimcore_version: "", phpstan_args: "", experimental: false }
-                    - { php-version: "8.4", dependencies: "highest", pimcore_version: "12.x-dev", phpstan_args: "", experimental: true }
         steps:
             - name: "Checkout code"
               uses: "actions/checkout@v2"


### PR DESCRIPTION
Removed experimental configuration for pimcore version 12.x-dev.
This bundle won't be used in the next pimcore/pimcore major, removing this experimental test